### PR TITLE
Read events feature

### DIFF
--- a/src/aces.json
+++ b/src/aces.json
@@ -1142,23 +1142,7 @@
         "highlight": false,
         "returnType": "number",
         "params": []
-      },
-      {
-        "id": "get-event-name",
-        "expressionName": "GetEventName",
-        "scriptName": "GetEventName",
-        "highlight": false,
-        "returnType": "string",
-        "params": []
-      },
-      {
-        "id": "get-event-track-index",
-        "expressionName": "GetEventTrackIndex",
-        "scriptName": "GetEventTrackIndex",
-        "highlight": false,
-        "returnType": "string",
-        "params": []
-      },      
+      },   
       {
         "id": "get-event-data",
         "expressionName": "GetEventData",

--- a/src/aces.json
+++ b/src/aces.json
@@ -224,6 +224,18 @@
         ]
       },
       {
+        "id": "on-any-event",
+        "scriptName": "OnAnyEvent",
+        "isTrigger": true,
+        "params": [
+          {
+            "id": "track-index",
+            "type": "number",
+            "initial-value": 0
+          }
+        ]
+      },      
+      {
         "id": "is-bone-control-property-active",
         "scriptName": "IsBoneControlPropertyActive",
         "isTrigger": false,
@@ -1130,7 +1142,36 @@
         "highlight": false,
         "returnType": "number",
         "params": []
-      }
+      },
+      {
+        "id": "get-event-name",
+        "expressionName": "GetEventName",
+        "scriptName": "GetEventName",
+        "highlight": false,
+        "returnType": "string",
+        "params": []
+      },
+      {
+        "id": "get-event-track-index",
+        "expressionName": "GetEventTrackIndex",
+        "scriptName": "GetEventTrackIndex",
+        "highlight": false,
+        "returnType": "string",
+        "params": []
+      },      
+      {
+        "id": "get-event-data",
+        "expressionName": "GetEventData",
+        "scriptName": "GetEventData",
+        "highlight": false,
+        "returnType": "any",
+        "params": [
+          {
+            "id": "field",
+            "type": "string"            
+          }
+        ]
+      }            
     ]
   }
 }

--- a/src/c3runtime/conditions.js
+++ b/src/c3runtime/conditions.js
@@ -44,7 +44,9 @@
         OnEvent(eventName, trackIndex) {
             return (this.completeEventName === eventName) && (this.completeEventTrackIndex === trackIndex);
         },
-
+        OnAnyEvent(trackIndex) {
+            return (this.completeEventTrackIndex === trackIndex);
+        },        
         IsBoneControlPropertyActive(bone, propertyIndex) {
             let properties=['x','y','rotation','scaleX','scaleY'];
             let property = properties[propertyIndex];

--- a/src/c3runtime/expressions.js
+++ b/src/c3runtime/expressions.js
@@ -315,12 +315,6 @@
        SkeletonScale(){
         return this.skeletonScale;   
        },
-       GetEventName() {
-        return this.completeEventName;
-       },
-       GetEventTrackIndex() {
-        return this.completeEventTrackIndex;
-       },
        GetEventData(field) {
         const fieldList = ["float", "int", "string", "balance", "volume", "audiopath", "event", "track"]
 

--- a/src/c3runtime/expressions.js
+++ b/src/c3runtime/expressions.js
@@ -314,6 +314,23 @@
        },
        SkeletonScale(){
         return this.skeletonScale;   
+       },
+       GetEventName() {
+        return this.completeEventName;
+       },
+       GetEventTrackIndex() {
+        return this.completeEventTrackIndex;
+       },
+       GetEventData(field) {
+        const fieldList = ["float", "int", "string", "balance", "volume", "audiopath", "event", "track"]
+
+        if (!(fieldList.includes(field)))
+            return "";
+
+        if (!(field in this.completeEventData))
+            return "";
+        
+        return this.completeEventData[field];
        }
     };
 }

--- a/src/c3runtime/instance.js
+++ b/src/c3runtime/instance.js
@@ -87,6 +87,8 @@
             this.completeEventName = ""
             this.textureWidth = 0;
             this.textureHeight = 0;
+            this.completeEventData = { }
+
 
             // @ts-ignore
             const wi = this.GetWorldInfo();
@@ -290,6 +292,7 @@
             stateData.defaultMix = this.defaultMix;
             // @ts-ignore
             var state = new spine.AnimationState(stateData);
+
             state.setAnimation(0, animationName, true);
             // Record animation assigned for listener
             this.trackAnimations[0] = this.animationName;
@@ -304,9 +307,22 @@
                 },
                 event: (trackEntry, event) => {
                     this.completeEventName = event.data.name;
-                    this.completeEventTrackIndex = trackEntry.trackIndex;
+                    this.completeEventTrackIndex = trackEntry.trackIndex;                        
+                   
+                    this.completeEventData = {
+                        'float'     : event.floatValue,
+                        'int'       : event.intValue,
+                        'string'    : event.stringValue,
+                        'balance'   : event.balance,
+                        'volume'    : event.volume,
+                        'audiopath' : event.data.audioPath,
+                        'event'     : event.data.name,
+                        'track'     : trackEntry.trackIndex
+                    }
+
                     // @ts-ignore
                     this.Trigger(C3.Plugins.Gritsenko_Spine.Cnds.OnEvent);
+                    this.Trigger(C3.Plugins.Gritsenko_Spine.Cnds.OnAnyEvent);
                 }
             };
 
@@ -496,9 +512,22 @@
                 },
                 event: (trackEntry, event) => {
                     this.completeEventName = event.data.name;
-                    this.completeEventTrackIndex = trackEntry.trackIndex;
+                    this.completeEventTrackIndex = trackEntry.trackIndex;                    
+
+                    this.completeEventData = {
+                        'float'     : event.floatValue,
+                        'int'       : event.intValue,
+                        'string'    : event.stringValue,
+                        'balance'   : event.balance,
+                        'volume'    : event.volume,
+                        'audiopath' : event.data.audioPath,
+                        'event'     : event.data.name,
+                        'track'     : trackEntry.trackIndex                        
+                    }
+
                     // @ts-ignore
                     this.Trigger(C3.Plugins.Gritsenko_Spine.Cnds.OnEvent);
+                    this.Trigger(C3.Plugins.Gritsenko_Spine.Cnds.OnAnyEvent);
                 }
             };   
         }
@@ -648,6 +677,7 @@
             this.spineError = null
             this.animationSpeed = null;
             this.completeEventName = null;
+            this.completeEventData = null;
             this.skeletonRenderQuality = null;
             this.textureWidth = null;
             this.textureHeight = null;

--- a/src/c3runtime/spine-webgl.js
+++ b/src/c3runtime/spine-webgl.js
@@ -8135,6 +8135,7 @@ var spine = (() => {
         linkedMesh.mesh.updateUVs();
       }
       this.linkedMeshes.length = 0;
+
       if (root.events) {
         for (let eventName in root.events) {
           let eventMap = root.events[eventName];
@@ -8699,6 +8700,7 @@ var spine = (() => {
           let eventMap = map.events[i];
           let eventData = skeletonData.findEvent(eventMap.name);
           let event = new Event(Utils.toSinglePrecision(getValue(eventMap, "time", 0)), eventData);
+          
           event.intValue = getValue(eventMap, "int", eventData.intValue);
           event.floatValue = getValue(eventMap, "float", eventData.floatValue);
           event.stringValue = getValue(eventMap, "string", eventData.stringValue);
@@ -8787,7 +8789,8 @@ var spine = (() => {
     return bezier + 1;
   }
   function getValue(map, property, defaultValue) {
-    return map[property] !== void 0 ? map[property] : defaultValue;
+    //return map[property] !== void 0 ? map[property] : defaultValue;
+    return (property in map) ? map[property] : defaultValue;
   }
 
   // spine-core/src/polyfills.ts

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1096,17 +1096,7 @@
             "description": "Skeleton scale",
             "translated-name": "SkeletonScale",
             "params": {}
-          },
-          "get-event-name": {
-            "description": "Get current event name on the current track",
-            "translated-name": "GetEventName",
-            "params": {}
-          },
-          "get-event-track-index": {
-            "description": "Get track index of the current event",
-            "translated-name": "GetEventTrackIndex",
-            "params": {}
-          },          
+          },        
           "get-event-data": {
             "description": "Get value field of the current event",
             "translated-name": "GetEventData",          

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -194,7 +194,7 @@
           },
           "on-any-event": {
             "list-name": "On any animation event",
-            "display-text": "On any event on track {0}",
+            "display-text": "On any animation event on track {0}",
             "description": "Triggered on any event on specified track.",
             "params": {
               "track-index": {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -192,6 +192,17 @@
               }
             }
           },
+          "on-any-event": {
+            "list-name": "On any animation event",
+            "display-text": "On any event on track {0}",
+            "description": "Triggered on any event on specified track.",
+            "params": {
+              "track-index": {
+                "name": "Track index",
+                "desc": "Track index"
+              }
+            }
+          },          
           "is-bone-control-property-active": {
             "list-name": "Is bone control property active",
             "display-text": "Is {0} {1} control active",
@@ -1085,7 +1096,27 @@
             "description": "Skeleton scale",
             "translated-name": "SkeletonScale",
             "params": {}
-          }
+          },
+          "get-event-name": {
+            "description": "Get current event name on the current track",
+            "translated-name": "GetEventName",
+            "params": {}
+          },
+          "get-event-track-index": {
+            "description": "Get track index of the current event",
+            "translated-name": "GetEventTrackIndex",
+            "params": {}
+          },          
+          "get-event-data": {
+            "description": "Get value field of the current event",
+            "translated-name": "GetEventData",          
+            "params": {
+              "field": {
+                "name": "Field",
+                "desc": "The field of the event data to read (float,int,string,balance,volume,audiopath,event,track)"
+              }
+            }
+          }             
         }
       }
     }


### PR DESCRIPTION
Fix to read animation event values and new expression to read it in C3 ADDON.

Features:

- Fix on "spine-webgl.js" library to set correctly the animation event values.   Before these values always are zero or empty string.
- Added new expression GetEventData to read event values (float, int, string, audiopath, volume, balance, event, track). 
- Added a new condition on C3 AddOn "On any animation event" usefull to use with the new expressions.